### PR TITLE
Remove black/flake8/mypy from main dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ fastapi = "*"
 pydantic = "^1.0"
 sqlalchemy =  { version = "^1.3.12", optional = true }
 psutil = "^5.8.0"
-black = "^21.12b0"
-flake8 = "^4.0.1"
-mypy = "^0.931"
 
 [tool.poetry.dev-dependencies]
 # Starlette features


### PR DESCRIPTION
black/flake8/mypy are already listed in dev-dependencies, and listing them in main dependencies propagates to other projects.

This fixes https://github.com/yuval9313/FastApi-RESTful/issues/121